### PR TITLE
Load overlay kernel module to speed up DinD

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,6 +44,12 @@
   service: name=docker state=started enabled=yes
   become: True
 
+- name: load overlay kernel module for docker
+  modprobe:
+    name: overlay
+    state: present
+  become: True
+
 - name: upgrade pip so package installs are not broken
   pip:
     name: pip


### PR DESCRIPTION
When running Docker-in-Docker (which is a reasonable thing to do when
running GitLab runners), it is recommended that one set
DOCKER_DRIVER=overlay for performance reasons. This requires loading the
"overlay" kernel module, so load this module before registering any
runners.