### PR TITLE
Use overlay2 instead of overlay

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,7 @@
 
 - name: create config for Docker storage setup
   copy:
-    content: "STORAGE_DRIVER=overlay"
+    content: "STORAGE_DRIVER=overlay2"
     dest: "/etc/sysconfig/docker-storage-setup"
   when: docker_storage_device is defined
   become: True


### PR DESCRIPTION
Since overlay2 now works with the latest CentOS, use that instead of
overlay. Red Hat has backported the support even though the kernel
version is < 4.