### PR TITLE
Fix runner unregister in gitlab_runner_rpm.yml

### DIFF
--- a/tasks/gitlab_runner_rpm.yml
+++ b/tasks/gitlab_runner_rpm.yml
@@ -10,7 +10,6 @@
 
 - name: unregister runner gitlab-runner-{{ runner_config.RUNNER_NAME }}
   shell: >
-    docker exec gitlab-runner-{{ runner_config.RUNNER_NAME }}
     gitlab-ci-multi-runner unregister -n {{ runner_config.RUNNER_NAME }}
   become: True
   when:


### PR DESCRIPTION
The docker exec command had been left in gitlab_runner_rpm.yml where it
doesn't work because there's no container to run the docker exec in.
Remove the docker exec part so that the shell command runs in the normal
local shell and doesn't throw an error.